### PR TITLE
コメントのユーザー名からユーザ画面へ遷移

### DIFF
--- a/front/topicslab/src/components/Comments.vue
+++ b/front/topicslab/src/components/Comments.vue
@@ -2,7 +2,9 @@
   <div>
     <Fieldset v-for="comment in comments" :key="comment.id">
       <template #legend>
-        <span>{{comment.user.name}}</span>
+        <span>
+          <router-link :to="`/user/${comment.user.id}`">{{comment.user.name}}</router-link>
+        </span>
       </template>
       <div class="comment-text">
         {{comment.body}}


### PR DESCRIPTION
コメント文のユーザ名をクリックすると、ユーザ画面へと遷移するようリンクを追加しました。
(項目8,9を飛ばして、項目10)